### PR TITLE
refactor: if/else priority options

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -7,11 +7,10 @@ branding:
 inputs:
   job-name:
     description: 'Optional name of the annotation author.'
-  lint-all:	
+  lint-all:
     description: 'Lint all files.'
   custom-glob:
     description: 'Custom glob to overwrite which files to lint. Delimited by a comma(,).'
-    
 runs:
   using: 'node12'
   main: 'dist/index.js'

--- a/action.yml
+++ b/action.yml
@@ -7,10 +7,11 @@ branding:
 inputs:
   job-name:
     description: 'Optional name of the annotation author.'
-  lint-all:
+  lint-all:	
     description: 'Lint all files.'
   custom-glob:
-    description: 'Custom glob to overwrite which files to lint. Delimited by a comma(,). This option only works with lint-all enabled.'
+    description: 'Custom glob to overwrite which files to lint. Delimited by a comma(,).'
+    
 runs:
   using: 'node12'
   main: 'dist/index.js'

--- a/src/main.ts
+++ b/src/main.ts
@@ -15,7 +15,7 @@ async function lint(files: string[] | undefined, lintAll?: string, customGlob?: 
 		ignorePath: '.gitignore'
 	});
 	let filesToLint = files || ['src']; // Default fallback
-	if(lintAll) {
+	if (lintAll) {
 		filesToLint = ['src']
 	} else if (customGlob) {
 		filesToLint = customGlob.split(',');

--- a/src/main.ts
+++ b/src/main.ts
@@ -14,17 +14,11 @@ async function lint(files: string[] | undefined, lintAll?: string, customGlob?: 
 		extensions: [...EXTENSIONS],
 		ignorePath: '.gitignore'
 	});
-	let filesToLint;
-	if (customGlob && lintAll) {
-		filesToLint = customGlob.split(',');
-	} else if (lintAll) {
-		filesToLint = ['src'];
-	} else if (files) {
-		filesToLint = files;
+	let filesToLint = files || ['src']; // Default fallback
+	if(lintAll) {
+		filesToLint = ['src']
 	} else if (customGlob) {
 		filesToLint = customGlob.split(',');
-	} else {
-		filesToLint = ['src'];
 	}
 	const report = cli.executeOnFiles(filesToLint);
 	const { results, errorCount, warningCount } = report;


### PR DESCRIPTION
Hello again 😄 

(Edit: after reviewing my PR)

So I have edit the way files are "picked up" since this was a messy if/else.

So now we have the default fallback that is ['src']. 
If lint-all is transmitted, it forced the ['src'] path
If glob is transmitted, it forced the glob.

Lint-all and glob can't be transmitted at the same time, maybe add a warning for it ?